### PR TITLE
Adding missing method expected from qgis-plug-ci: delete()

### DIFF
--- a/pytransifex/api.py
+++ b/pytransifex/api.py
@@ -79,6 +79,12 @@ class Client(Tx):
                 logging.error(f"Unable to create project; API replied with {error}")
 
     @ensure_login
+    def delete_project(self, project_slug: str):
+        if project := self.get_project(project_slug=project_slug):
+            project.delete()
+            logging.info(f"Deleted project: {project_slug}")
+
+    @ensure_login
     def get_project(self, project_slug: str) -> None | Resource:
         """Fetches the project matching the given slug"""
         if self.projects:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,9 +29,8 @@ class TestNewApi(unittest.TestCase):
                 f"Unable to complete test with broken tests inputs. Found missing: {missing}"
             )
 
-        if project := cls.tx.get_project(project_slug=cls.project_slug):
-            logging.info("Found old project, removing.")
-            project.delete()
+        logging.info("Deleting test project if it already exists")
+        cls.tx.delete_project(project_slug=cls.project_slug)
 
         logging.info("Creating a brand new project")
         cls.tx.create_project(


### PR DESCRIPTION
I wish I had caught this earlier in qgis-plugin-ci. Apparently the "missing method/attribute" exception was swallowed in qgis-plugin-ci:translation.py -- that's why.